### PR TITLE
Adds dockerfile for development

### DIFF
--- a/Dockerfile.devel
+++ b/Dockerfile.devel
@@ -1,0 +1,17 @@
+ARG PG_VERSION
+ARG FDW_VERSION
+FROM postgres:${PG_VERSION}-alpine as build
+
+RUN apk --no-cache add curl python3 gcc g++ make musl-dev openssl-dev cmake curl-dev util-linux-dev;\
+    chmod a+rwx /usr/local/lib/postgresql && \
+    chmod a+rwx /usr/local/share/postgresql/extension && \
+    mkdir -p /usr/local/share/doc/postgresql/contrib && \
+    chmod a+rwx /usr/local/share/doc/postgresql/contrib
+
+RUN wget -O fdw.zip -c https://github.com/adjust/clickhouse_fdw/archive/refs/tags/$FDW_VERSION.zip && \
+	unzip fdw.zip && \
+	cd clickhouse_fdw-$FDW_VERSION && mkdir build && cd build && cmake .. && make && DESTDIR=/tmp/data make install
+
+FROM postgres:${PG_VERSION}-alpine as install
+RUN apk --no-cache add libcurl
+COPY --from=build /tmp/data/ /


### PR DESCRIPTION
Provided another container running clickhouse, called clickhouse-experiments:

1. `docker build . --build-arg PG_VERSION=12 FDW_VERSION=1.3.0 -t postgres_clickhouse:latest -f Dockerfile.devel`
2. `docker run --name postgres_clickhouse_1 -d -p5432:5432 -e POSTGRES_AUTH_METHOD=trust -e POSTGRES_PASSWORD=pass postgres_clickhouse`

3. `docker network create my-network`
4. `docker network connect my-network clickhouse-experiments`
5. `docker network connect my-network postgres_clickhouse_1`

6. Configure postgres

```sql
CREATE EXTENSION clickhouse_fdw;
DROP SERVER IF EXISTS clickhouse_svr CASCADE;
CREATE SERVER clickhouse_svr FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'benchmark', driver 'binary', host 'clickhouse-experiments');
CREATE USER MAPPING FOR CURRENT_USER SERVER clickhouse_svr OPTIONS (user 'default', password '');
IMPORT FOREIGN SCHEMA "benchmark" FROM SERVER clickhouse_svr INTO public;
```